### PR TITLE
chore: Add Stackable Cockpit task

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -36,6 +36,7 @@ This will not be so crucial with release branches, but is nonetheless sensible a
 - [ ] Create release tag(s) for docker-images (see stackable-utils for scripts to create tags)
 - [ ] Create release branches for operators (see stackable-utils for script to create branches)
 - [ ] Create release tag(s) for operators (see stackable-utils for scripts to create tags)
+- [ ] Create release tag for stackable-cockpit (optional, highly experimental, requires manual tag creation)
 - [ ] Ping the stackable-ionos-tech channel or anyone responsible once all tags are created
 - [ ] Update changelogs in main branches (see stackable-utils for script to do this)
 - [ ] Check integration tests (use a table in Nuclino - easier for concurrent editing)


### PR DESCRIPTION
Adds a task to release a new Stackable Cockpit release. Currently blocked by https://github.com/stackabletech/stackable-cockpit/pull/111