### PR TITLE
chore: Restore container images tracking issue.

### DIFF
--- a/.github/ISSUE_TEMPLATE/pre-release-container-images.md
+++ b/.github/ISSUE_TEMPLATE/pre-release-container-images.md
@@ -1,0 +1,176 @@
+---
+name: Product version updates
+about: Use this template once per SDP release to track the product updates we need to do
+title: Update products
+labels: ''
+assignees: ''
+
+---
+
+This issue tracks the product versions and the changes we need to do to them in our SDP release XX.XX.
+
+The single source of truth for this data is a [spreadsheet](https://docs.google.com/spreadsheets/d/1uR6nJR3nMxSI51dPFbVJTqA4R3p7UkGU5acrXJNOyNQ/edit#gid=866098130) we filled colaboratively in a planning meeting.
+
+## Acceptance 
+
+We want to bump old and new product versions with the latest ubi image releases.
+This includes our [Java base image](https://github.com/stackabletech/docker-images/tree/main/java-base) which should be done before updating any Java based products.
+It also includes bumping to the latest supported JVM version.
+
+### Base images
+
+#### UBI8 Rust Builder
+
+[ubi8-rust-builder](https://github.com/stackabletech/docker-images/blob/main/ubi8-rust-builder/Dockerfile)
+
+```[tasklist]
+- [ ] Update UBI version
+- [ ] Update Cargo CycloneDX and Cargo Auditable
+- [ ] Update Rust Toolchain version
+- [ ] Update `protoc` version
+```
+
+#### UBI9 Rust Builder
+
+[ubi9-rust-builder](https://github.com/stackabletech/docker-images/blob/main/ubi9-rust-builder/Dockerfile)
+
+```[tasklist]
+- [ ] Update UBI version
+- [ ] Update Cargo CycloneDX and Cargo Auditable
+- [ ] Update Rust Toolchain version
+- [ ] Update `protoc` version
+```
+
+#### Java Base
+
+Nothing currently needs to be updated here
+
+#### Stackable Base
+
+[stackable-base](https://github.com/stackabletech/docker-images/blob/main/stackable-base/Dockerfile)
+
+```[tasklist]
+- [ ] Update UBI version
+- [ ] Update Cargo CycloneDX and Cargo Auditable
+- [ ] Update Rust Toolchain version
+- [ ] Update `protoc` version
+- [ ] Update config-utils version
+```
+
+### Product Images
+
+- Make sure to _also_ check any other dependencies we might use in a Docker image! (e.g. git sync, prometheus exporter etc.)
+
+#### Airflow
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+#### Druid
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] JVM is at latest supported version
+- [ ] Documentation is updated
+- [ ] Operator is updated
+- [ ] Update the [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) with the new set of versions
+```
+
+#### HBase, Phoenix, Omid
+
+NOTE: Make sure to also consider Omid & Phoenix
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] JVM is at latest supported version
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+#### HDFS
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] JVM is at latest supported version
+- [ ] Documentation is updated
+- [ ] Operator is updated
+- [ ] Update Authorizer, Group Mapper and Rack Awareness stuff if needed
+```
+
+#### Hive
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] JVM is at latest supported version
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+#### Kafka
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] JVM is at latest supported version
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+#### NiFi
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] JVM is at latest supported version
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+#### OpenPolicyAgent (OPA)
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+#### Spark
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] JVM is at latest supported version
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+#### Superset
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+#### Trino
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+#### ZooKeeper
+
+```[tasklist]
+- [ ] Versions are updated in accordinance to the source of truth spreadsheet
+- [ ] JVM is at latest supported version
+- [ ] Documentation is updated
+- [ ] Operator is updated
+```
+
+### Misc
+
+```[tasklist]
+- [ ] Update the Stackable DB
+```

--- a/.github/ISSUE_TEMPLATE/pre-release-container-images.md
+++ b/.github/ISSUE_TEMPLATE/pre-release-container-images.md
@@ -23,38 +23,62 @@ It also includes bumping to the latest supported JVM version.
 
 [ubi8-rust-builder](https://github.com/stackabletech/docker-images/blob/main/ubi8-rust-builder/Dockerfile)
 
+- [ ] Update UBI version hash in the Dockerfile (`FROM`)
+- [ ] Update `RUST_DEFAULT_TOOLCHAIN_VERSION`
+- [ ] Update `CARGO_CYCLONEDX_CRATE_VERSION`
+- [ ] Update `CARGO_AUDITABLE_CRATE_VERSION`
+- [ ] Update `PROTOC_VERSION`
+
 ```[tasklist]
-- [ ] Update UBI version
-- [ ] Update Cargo CycloneDX and Cargo Auditable
-- [ ] Update Rust Toolchain version
-- [ ] Update `protoc` version
+### Related Pull Requests
+- [ ] _Link to PR here_
+- [ ] _Link to operator-rs PR_
+- [ ] _Link to operator-templating PR_
 ```
 
 #### UBI9 Rust Builder
 
 [ubi9-rust-builder](https://github.com/stackabletech/docker-images/blob/main/ubi9-rust-builder/Dockerfile)
 
+- [ ] Update UBI version hash in the Dockerfile (`FROM`)
+- [ ] Update `RUST_DEFAULT_TOOLCHAIN_VERSION`
+- [ ] Update `CARGO_CYCLONEDX_CRATE_VERSION`
+- [ ] Update `CARGO_AUDITABLE_CRATE_VERSION`
+- [ ] Update `PROTOC_VERSION`
+
 ```[tasklist]
-- [ ] Update UBI version
-- [ ] Update Cargo CycloneDX and Cargo Auditable
-- [ ] Update Rust Toolchain version
-- [ ] Update `protoc` version
+### Related Pull Requests
+- [ ] _Link to PR here_
+- [ ] _Link to operator-rs PR_
+- [ ] _Link to operator-templating PR_
 ```
 
-#### Java Base
+#### Java Base and Devel
 
-Nothing currently needs to be updated here
+> [!CAUTION]
+> Any additions to the `java-base` or `java-devel` versions need to be there before updating Java based products.
+
+```[tasklist]
+### Related Pull Requests
+- [ ] Does anything need doing here?
+```
 
 #### Stackable Base
 
 [stackable-base](https://github.com/stackabletech/docker-images/blob/main/stackable-base/Dockerfile)
 
+- [ ] Update UBI version hash in the Dockerfile (`FROM`)
+- [ ] Update `RUST_DEFAULT_TOOLCHAIN_VERSION`
+- [ ] Update `CARGO_CYCLONEDX_CRATE_VERSION`
+- [ ] Update `CARGO_AUDITABLE_CRATE_VERSION`
+- [ ] Update `PROTOC_VERSION`
+- [ ] Update `CONFIG_UTILS_VERSION`
+
 ```[tasklist]
-- [ ] Update UBI version
-- [ ] Update Cargo CycloneDX and Cargo Auditable
-- [ ] Update Rust Toolchain version
-- [ ] Update `protoc` version
-- [ ] Update config-utils version
+### Related Pull Requests
+- [ ] _Link to PR here_
+- [ ] _Link to operator-rs PR_
+- [ ] _Link to operator-templating PR_
 ```
 
 ### Product Images
@@ -64,109 +88,144 @@ Nothing currently needs to be updated here
 #### Airflow
 
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 #### Druid
 
+> [!IMPORTANT]
+> Bump the JVM to the latest supported version.
+
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] JVM is at latest supported version
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 - [ ] Update the [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) with the new set of versions
 ```
 
 #### HBase, Phoenix, Omid
 
-NOTE: Make sure to also consider Omid & Phoenix
+> [!IMPORTANT]
+> Bump the JVM to the latest supported version.
+>
+> Also consider Omid & Phoenix
 
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] JVM is at latest supported version
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 #### HDFS
 
+> [!IMPORTANT]
+> Bump the JVM to the latest supported version.
+
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] JVM is at latest supported version
-- [ ] Documentation is updated
-- [ ] Operator is updated
-- [ ] Update Authorizer, Group Mapper and Rack Awareness stuff if needed
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
+- [ ] Update Authorizer (if needed)
+- [ ] Update Group Mapper (if needed)
+- [ ] Update Rack Awareness (if needed)
 ```
 
 #### Hive
 
+> [!IMPORTANT]
+> Bump the JVM to the latest supported version.
+
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] JVM is at latest supported version
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 #### Kafka
 
+> [!IMPORTANT]
+> Bump the JVM to the latest supported version
+
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] JVM is at latest supported version
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 #### NiFi
 
+> [!IMPORTANT]
+> Bump the JVM to the latest supported version
+
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] JVM is at latest supported version
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 #### OpenPolicyAgent (OPA)
 
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 #### Spark
 
+> [!IMPORTANT]
+> Bump the JVM to the latest supported version.
+
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] JVM is at latest supported version
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 #### Superset
 
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 #### Trino
 
+> [!IMPORTANT]
+> Bump the JVM to the latest supported version.
+>
+> Also consider updating trino-cli in the same PR.
+
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 #### ZooKeeper
 
+> [!IMPORTANT]
+> Bump the JVM to the latest supported version.
+
 ```[tasklist]
-- [ ] Versions are updated in accordinance to the source of truth spreadsheet
-- [ ] JVM is at latest supported version
-- [ ] Documentation is updated
-- [ ] Operator is updated
+### Related Pull Requests
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
+- [ ] Update the versions used in the operator
+- [ ] Update the versions used in demos
 ```
 
 ### Misc

--- a/.github/ISSUE_TEMPLATE/pre-release-container-images.md
+++ b/.github/ISSUE_TEMPLATE/pre-release-container-images.md
@@ -13,9 +13,15 @@ The single source of truth for this data is a [spreadsheet](https://docs.google.
 
 ## Acceptance 
 
-We want to bump old and new product versions with the latest ubi image releases.
-This includes our [Java base image](https://github.com/stackabletech/docker-images/tree/main/java-base) which should be done before updating any Java based products.
-It also includes bumping to the latest supported JVM version.
+These high level tasks need to be completed.
+
+> [!IMPORTANT]
+> At the end, these should be checked based on the more granular criterea for each product/image below.
+
+- [ ] Bump UBI Image releases.
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Update product version references in getting_started docs, kuttl tests, and demos.
+- [ ] Update the Stackable DB.
 
 ### Base images
 
@@ -304,10 +310,4 @@ Used as a base for `java-base`.
 - [ ] _Link to operator PR (getting_started / kuttl)_
 - [ ] _Link to other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (Do not merge until demos are released)_
-```
-
-### Misc
-
-```[tasklist]
-- [ ] Update the Stackable DB
 ```

--- a/.github/ISSUE_TEMPLATE/pre-release-container-images.md
+++ b/.github/ISSUE_TEMPLATE/pre-release-container-images.md
@@ -57,6 +57,26 @@ It also includes bumping to the latest supported JVM version.
 - [ ] _Link to operator-templating PR_
 ```
 
+#### Vector
+
+> [!CAUTION]
+> Any additions to the versions need to be there before updating the `java-base`.
+
+Used as a base for `java-base`.
+
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
+
+```[tasklist]
+### Related Pull Requests
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
+```
+
 #### Java Base and Devel
 
 > [!CAUTION]
@@ -91,145 +111,199 @@ It also includes bumping to the latest supported JVM version.
 
 #### Airflow
 
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
+
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### Druid
 
-> [!IMPORTANT]
-> Bump the JVM to the latest supported version.
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
+- [ ] Update the [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) with the new set of versions.
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
 
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
-- [ ] Update the [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) with the new set of versions
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
+- [ ] _Link to [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) PR_
 ```
 
 #### HBase, Phoenix, Omid
 
-> [!IMPORTANT]
-> Bump the JVM to the latest supported version.
->
-> Also consider Omid & Phoenix
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
+- [ ] Update Omid.
+- [ ] Update Phoenix.
 
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### HDFS
 
-> [!IMPORTANT]
-> Bump the JVM to the latest supported version.
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
+- [ ] Check Authorizer (unknown procedure)
+- [ ] Check Group Mapper (unknown procedure)
+- [ ] Check Rack Awareness (unknown procedure)
 
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
-- [ ] Update Authorizer (if needed)
-- [ ] Update Group Mapper (if needed)
-- [ ] Update Rack Awareness (if needed)
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### Hive
 
-> [!IMPORTANT]
-> Bump the JVM to the latest supported version.
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
 
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### Kafka
 
-> [!IMPORTANT]
-> Bump the JVM to the latest supported version
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
 
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### NiFi
 
-> [!IMPORTANT]
-> Bump the JVM to the latest supported version
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
 
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### OpenPolicyAgent (OPA)
 
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
+
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### Spark
 
-> [!IMPORTANT]
-> Bump the JVM to the latest supported version.
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
+- [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### Superset
 
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
+
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### Trino
 
-> [!IMPORTANT]
-> Bump the JVM to the latest supported version.
->
-> Also consider updating trino-cli in the same PR.
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
+- [ ] Update trino-cli.
 
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 #### ZooKeeper
 
-> [!IMPORTANT]
-> Bump the JVM to the latest supported version.
+**Acceptance criterea:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+- [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
+- [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
 
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet
-- [ ] Update the versions used in the operator
-- [ ] Update the versions used in demos
+- [ ] _Link to PR_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (Do not merge until demos are released)_
 ```
 
 ### Misc

--- a/.github/ISSUE_TEMPLATE/pre-release-container-images.md
+++ b/.github/ISSUE_TEMPLATE/pre-release-container-images.md
@@ -68,9 +68,9 @@ These high level tasks need to be completed.
 > [!CAUTION]
 > Any additions to the versions need to be there before updating the `java-base`.
 
-Used as a base for `java-base`.
+Used as a base for [java-base](https://github.com/stackabletech/docker-images/blob/main/java-base/Dockerfile).
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
@@ -88,9 +88,13 @@ Used as a base for `java-base`.
 > [!CAUTION]
 > Any additions to the `java-base` or `java-devel` versions need to be there before updating Java based products.
 
+**Actions to take:**
+
+- [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
+
 ```[tasklist]
 ### Related Pull Requests
-- [ ] Does anything need doing here?
+- [ ] _Link to PR_
 ```
 
 #### Stackable Base
@@ -117,7 +121,7 @@ Used as a base for `java-base`.
 
 #### Airflow
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
@@ -132,7 +136,7 @@ Used as a base for `java-base`.
 
 #### Druid
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
@@ -150,7 +154,7 @@ Used as a base for `java-base`.
 
 #### HBase, Phoenix, Omid
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
@@ -168,7 +172,7 @@ Used as a base for `java-base`.
 
 #### HDFS
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
@@ -187,7 +191,7 @@ Used as a base for `java-base`.
 
 #### Hive
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
@@ -203,7 +207,7 @@ Used as a base for `java-base`.
 
 #### Kafka
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
@@ -219,7 +223,7 @@ Used as a base for `java-base`.
 
 #### NiFi
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
@@ -235,7 +239,7 @@ Used as a base for `java-base`.
 
 #### OpenPolicyAgent (OPA)
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
@@ -250,7 +254,7 @@ Used as a base for `java-base`.
 
 #### Spark
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
@@ -266,7 +270,7 @@ Used as a base for `java-base`.
 
 #### Superset
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Check other operators (getting_started / kuttl) for usage of the versions. Add the PR to the list below.
@@ -281,7 +285,7 @@ Used as a base for `java-base`.
 
 #### Trino
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
@@ -298,7 +302,7 @@ Used as a base for `java-base`.
 
 #### ZooKeeper
 
-**Acceptance criterea:**
+**Actions to take:**
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet.
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).

--- a/.github/ISSUE_TEMPLATE/pre-release-container-images.md
+++ b/.github/ISSUE_TEMPLATE/pre-release-container-images.md
@@ -19,6 +19,10 @@ It also includes bumping to the latest supported JVM version.
 
 ### Base images
 
+> [!TIP]
+> The Rust upgrades should be done as and when needed by developers, rather than being tied to the product selection for a release.
+> Also, ensure `make run-dev` works before bumping the Rust version across the operators. 
+
 #### UBI8 Rust Builder
 
 [ubi8-rust-builder](https://github.com/stackabletech/docker-images/blob/main/ubi8-rust-builder/Dockerfile)


### PR DESCRIPTION
See: https://github.com/stackabletech/issues/pull/602#issuecomment-2269438613

It was removed in #605

- [ ] Decide what to do with [docker-images/pre-release.md](https://github.com/stackabletech/docker-images/blob/5324e044a8aaac10e68767ba2b3c39e2623724f1/.github/ISSUE_TEMPLATE/pre-release.md?plain=1) (remove it, or refactor it?)

